### PR TITLE
Track benchmarks on `main` branch using Bencher

### DIFF
--- a/ansible/readme.md
+++ b/ansible/readme.md
@@ -4,7 +4,7 @@ This directory contains the necessary scripts for the bench server's setup and m
 allow deploying the bench server application, installing its dependencies, and exposing it to the
 internet through HTTPS (including certificate renewal).
 
-Important notes: 
+Important notes:
 
 * Securing the server after setting up the operating system and creating users for server admins is not included.
 * Performing a deploy _will_ affect benchmarking results (for example due to compiling Rust code for `ci-bench-runner`).
@@ -31,9 +31,9 @@ will need to:
 1. Replace the placeholder secret values by real ones.
 
 Secrets will be injected in the Rust app configuration file, which can be found at
-[`roles/bench-app-service/templates/config.json`](roles/bench-app-service/templates/config.json). 
-If you are deploying the  app for testing purposes, you will probably need to override some variables like 
-`github_app_id`, `github_repo_owner` and `github_repo_name` to match yours. See the [testing](#testing) 
+[`roles/bench-app-service/templates/config.json`](roles/bench-app-service/templates/config.json).
+If you are deploying the  app for testing purposes, you will probably need to override some variables like
+`github_app_id`, `github_repo_owner` and `github_repo_name` to match yours. See the [testing](#testing)
 section for more information.
 
 ## General overview
@@ -67,12 +67,12 @@ Before starting, you will need:
 * A GitHub application configured according to the [GitHub app](../readme.md#github-app) section of
   the main README. The application **must** be installed on your fork of the rustls repo, with the required
   permissions.
-* If testing code changes to the `ci-bench-runner` app or Ansbile playbooks, a fork of this repository that 
+* If testing code changes to the `ci-bench-runner` app or Ansible playbooks, a fork of this repository that
   you control.
 
 ### Deployment
 
-To deploy to your test server, copy `inventory.ini` to a new file `test-inventory.ini`, and update 
+To deploy to your test server, copy `inventory.ini` to a new file `test-inventory.ini`, and update
 the `ansible_host` IP address in `test-inventory.ini` to point to your clean-slate server.
 
 You can then deploy using:
@@ -85,6 +85,7 @@ ansible-playbook \
   --extra_vars 'github_repo_name=rustls' \
   --extra-vars 'bench_app_repo=https://github.com/example/rustls-bench-app/' \
   --extra-vars 'bench_app_branch=example-branch' \
+  --extra-vars 'bencher_api_token=jwt_header.jwt_payload.jwt_verify_signature' \
   playbook.yml
 ```
 
@@ -92,3 +93,4 @@ ansible-playbook \
 * The `github_repo_owner` and `github_repo_name` should be configured to match your fork of the main Rustls repo.
 * The `bench_app_repo` and `bench_app_branch` should be configured to match your fork of this repository, and the
   branch you've pushed with your code changes (if applicable).
+* The `bencher_api_token` should be configured to a Bencher API token for [the `rustls` project](https://bencher.dev/perf/rustls)

--- a/ansible/readme.md
+++ b/ansible/readme.md
@@ -86,6 +86,8 @@ ansible-playbook \
   --extra-vars 'bench_app_repo=https://github.com/example/rustls-bench-app/' \
   --extra-vars 'bench_app_branch=example-branch' \
   --extra-vars 'bencher_api_token=jwt_header.jwt_payload.jwt_verify_signature' \
+  --extra-vars 'bencher_project_id=rustls' \
+  --extra-vars 'bencher_testbed_id=benchmarking-host' \
   playbook.yml
 ```
 
@@ -94,3 +96,5 @@ ansible-playbook \
 * The `bench_app_repo` and `bench_app_branch` should be configured to match your fork of this repository, and the
   branch you've pushed with your code changes (if applicable).
 * The `bencher_api_token` should be configured to a Bencher API token for [the `rustls` project](https://bencher.dev/perf/rustls)
+* The `bencher_project_id` should be configured to a Bencher Project UUID or slug. Optional value that defaults to `rustls`.
+* The `bencher_testbed_id` should be configured to a Bencher Testbed UUID or slug. Optional value that defaults to `benchmarking-host`.

--- a/ansible/roles/bench-app-service/templates/config.json
+++ b/ansible/roles/bench-app-service/templates/config.json
@@ -3,10 +3,11 @@
   "job_output_dir": "/home/{{app_user}}/server/job-output",
   "path_to_db": ":memory:",
   "webhook_secret": "{{ webhook_secret }}",
-  "github_app_id": {{ github_app_id }},
+  "github_app_id": "{{ github_app_id }}",
   "github_app_key": "{{ github_app_key.replace('\n', '\\n') }}",
   "github_repo_owner": "{{ github_repo_owner }}",
   "github_repo_name": "{{ github_repo_name }}",
   "sentry_dsn": "{{ sentry_dsn }}",
+  "bencher_api_token": "{{ bencher_api_token }}",
   "port": 3000
 }

--- a/ansible/roles/bench-app-service/templates/config.json
+++ b/ansible/roles/bench-app-service/templates/config.json
@@ -3,11 +3,13 @@
   "job_output_dir": "/home/{{app_user}}/server/job-output",
   "path_to_db": ":memory:",
   "webhook_secret": "{{ webhook_secret }}",
-  "github_app_id": "{{ github_app_id }}",
+  "github_app_id": {{ github_app_id }},
   "github_app_key": "{{ github_app_key.replace('\n', '\\n') }}",
   "github_repo_owner": "{{ github_repo_owner }}",
   "github_repo_name": "{{ github_repo_name }}",
   "sentry_dsn": "{{ sentry_dsn }}",
   "bencher_api_token": "{{ bencher_api_token }}",
+  "bencher_project_id": {{ bencher_project_id | default(None, true) | to_json }},
+  "bencher_testbed_id": {{ bencher_testbed_id | default(None, true) | to_json }},
   "port": 3000
 }

--- a/ansible/secrets.example.yml
+++ b/ansible/secrets.example.yml
@@ -18,3 +18,9 @@ letsencrypt_email: "example@example.com"
 
 # The API token for Bencher
 bencher_api_token: "jwt_header.jwt_payload.jwt_verify_signature"
+
+# The Bencher Project ID (optional)
+bencher_project_id: "rustls"
+
+# The Bencher Testbed ID (optional)
+bencher_testbed_id: "benchmarking-host"

--- a/ansible/secrets.example.yml
+++ b/ansible/secrets.example.yml
@@ -8,10 +8,13 @@ github_app_key: |-
   -----END RSA PRIVATE KEY-----
 
 # The secret that GitHub will use to sign webhook events
-webhook_secret: 'very secret string'
+webhook_secret: "very secret string"
 
 # The DSN used to log traces to Sentry
-sentry_dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0'
+sentry_dsn: "https://examplePublicKey@o0.ingest.sentry.io/0"
 
 # The email address used for the Let's Encrypt ACME account
-letsencrypt_email: 'example@example.com'
+letsencrypt_email: "example@example.com"
+
+# The API token for Bencher
+bencher_api_token: "jwt_header.jwt_payload.jwt_verify_signature"

--- a/ci-bench-runner/Cargo.lock
+++ b/ci-bench-runner/Cargo.lock
@@ -204,7 +204,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "bencher_client"
 version = "0.3.15"
-source = "git+https://github.com/bencherdev/bencher?rev=22bbfb6f#22bbfb6f2b1502a1f1d65df3f6af6a56e92c85e7"
+source = "git+https://github.com/bencherdev/bencher?rev=d0532976#d0532976155e49afaa9e2121a0f6a9ad5c654d29"
 dependencies = [
  "bencher_json",
  "chrono",
@@ -224,7 +224,7 @@ dependencies = [
 [[package]]
 name = "bencher_json"
 version = "0.3.15"
-source = "git+https://github.com/bencherdev/bencher?rev=22bbfb6f#22bbfb6f2b1502a1f1d65df3f6af6a56e92c85e7"
+source = "git+https://github.com/bencherdev/bencher?rev=d0532976#d0532976155e49afaa9e2121a0f6a9ad5c654d29"
 dependencies = [
  "bencher_valid",
  "chrono",
@@ -245,7 +245,7 @@ dependencies = [
 [[package]]
 name = "bencher_valid"
 version = "0.3.15"
-source = "git+https://github.com/bencherdev/bencher?rev=22bbfb6f#22bbfb6f2b1502a1f1d65df3f6af6a56e92c85e7"
+source = "git+https://github.com/bencherdev/bencher?rev=d0532976#d0532976155e49afaa9e2121a0f6a9ad5c654d29"
 dependencies = [
  "base64 0.21.5",
  "chrono",
@@ -693,21 +693,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,19 +1104,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1363,24 +1335,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1533,48 +1487,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9dfc0783362704e97ef3bd24261995a699468440099ef95d869b4d9732f829a"
-dependencies = [
- "bitflags 2.4.1",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.38",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f55da20b29f956fb01f0add8683eb26ee13ebe3ebd935e49898717c6b4b2830"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "ordered-float"
@@ -1960,12 +1876,10 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -1976,7 +1890,6 @@ dependencies = [
  "serde_urlencoded",
  "system-configuration",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower-service",
@@ -2901,16 +2814,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.38",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]

--- a/ci-bench-runner/Cargo.lock
+++ b/ci-bench-runner/Cargo.lock
@@ -202,6 +202,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bencher_client"
+version = "0.3.15"
+source = "git+https://github.com/bencherdev/bencher?rev=22bbfb6f#22bbfb6f2b1502a1f1d65df3f6af6a56e92c85e7"
+dependencies = [
+ "bencher_json",
+ "chrono",
+ "prettyplease",
+ "progenitor",
+ "progenitor-client",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "syn 2.0.38",
+ "thiserror",
+ "tokio",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "bencher_json"
+version = "0.3.15"
+source = "git+https://github.com/bencherdev/bencher?rev=22bbfb6f#22bbfb6f2b1502a1f1d65df3f6af6a56e92c85e7"
+dependencies = [
+ "bencher_valid",
+ "chrono",
+ "derive_more",
+ "once_cell",
+ "ordered-float",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "slug",
+ "thiserror",
+ "typeshare",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "bencher_valid"
+version = "0.3.15"
+source = "git+https://github.com/bencherdev/bencher?rev=22bbfb6f#22bbfb6f2b1502a1f1d65df3f6af6a56e92c85e7"
+dependencies = [
+ "base64 0.21.5",
+ "chrono",
+ "derive_more",
+ "email_address",
+ "git-validate",
+ "gix-hash",
+ "once_cell",
+ "ordered-float",
+ "regex-lite",
+ "schemars",
+ "serde",
+ "slug",
+ "thiserror",
+ "typeshare",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,6 +287,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c79ad7fb2dd38f3dabd76b09c6a5a20c038fc0213ef1e9afd30eb777f120f019"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -266,8 +340,10 @@ checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets",
 ]
 
@@ -277,6 +353,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
+ "bencher_client",
  "ctor",
  "hex",
  "hmac",
@@ -314,6 +391,12 @@ name = "const-oid"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation"
@@ -445,6 +528,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "deunicode"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71dbf1bf89c23e9cd1baf5e654f622872655f195b36588dc9dc38f7eda30758c"
+dependencies = [
+ "deunicode 1.4.1",
+]
+
+[[package]]
+name = "deunicode"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1abaf4d861455be59f64fd2b55606cb151fce304ede7165f410243ce96bde6"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,10 +580,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2153bd83ebc09db15bcbdc3e2194d901804952e3dc96967e1cd3b0c5c32d112"
 dependencies = [
  "serde",
 ]
@@ -518,6 +644,15 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "faster-hex"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239f7bfb930f820ab16a9cd95afc26f88264cf6905c960b340a615384aa3338a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "fastrand"
@@ -713,6 +848,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,6 +885,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
+name = "git-validate"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "390195f4569880a6b1c6be5172a37c32fe8b9d6f039c45e8dd84ecf4148e3f8b"
+dependencies = [
+ "bstr",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-hash"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1884c7b41ea0875217c1be9ce91322f90bde433e91d374d0e1276073a51ccc60"
+dependencies = [
+ "faster-hex",
+ "thiserror",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,6 +928,15 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1009,6 +1182,7 @@ checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.2",
+ "serde",
 ]
 
 [[package]]
@@ -1348,6 +1522,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "openapiv3"
+version = "2.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25316406f0191559189c56d99731b63130775de7284d98df5e976ce67882ca8a"
+dependencies = [
+ "indexmap 2.1.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1389,6 +1574,18 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "ordered-float"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "536900a8093134cf9ccf00a27deb3532421099e958d9dd431135d0c7543ca1e8"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+ "schemars",
+ "serde",
 ]
 
 [[package]]
@@ -1529,12 +1726,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "progenitor"
+version = "0.4.0"
+source = "git+https://github.com/oxidecomputer/progenitor?rev=a6bc0624803b9483983f03269533cc35db66a54b#a6bc0624803b9483983f03269533cc35db66a54b"
+dependencies = [
+ "progenitor-client",
+ "progenitor-impl",
+ "progenitor-macro",
+ "serde_json",
+]
+
+[[package]]
+name = "progenitor-client"
+version = "0.4.0"
+source = "git+https://github.com/oxidecomputer/progenitor?rev=a6bc0624803b9483983f03269533cc35db66a54b#a6bc0624803b9483983f03269533cc35db66a54b"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "percent-encoding",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+]
+
+[[package]]
+name = "progenitor-impl"
+version = "0.4.0"
+source = "git+https://github.com/oxidecomputer/progenitor?rev=a6bc0624803b9483983f03269533cc35db66a54b#a6bc0624803b9483983f03269533cc35db66a54b"
+dependencies = [
+ "getopts",
+ "heck",
+ "http",
+ "indexmap 2.1.0",
+ "openapiv3",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "schemars",
+ "serde",
+ "serde_json",
+ "syn 2.0.38",
+ "thiserror",
+ "typify",
+ "unicode-ident",
+]
+
+[[package]]
+name = "progenitor-macro"
+version = "0.4.0"
+source = "git+https://github.com/oxidecomputer/progenitor?rev=a6bc0624803b9483983f03269533cc35db66a54b#a6bc0624803b9483983f03269533cc35db66a54b"
+dependencies = [
+ "openapiv3",
+ "proc-macro2",
+ "progenitor-impl",
+ "quote",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_tokenstream",
+ "serde_yaml",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1568,6 +1839,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
@@ -1606,6 +1878,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.10",
+ "serde",
 ]
 
 [[package]]
@@ -1650,10 +1923,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b661b2f27137bdbc16f00eda72866a92bb28af1753ffbd56744fb6e2e9cd8e"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "regress"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ed9969cad8051328011596bf549629f1b800cf1731e7964b1eef8dfc480d2c2"
+dependencies = [
+ "hashbrown 0.13.2",
+ "memchr",
+]
 
 [[package]]
 name = "reqwest"
@@ -1689,10 +1978,12 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
  "winreg",
@@ -1743,6 +2034,15 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -1822,6 +2122,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7b0ce13155372a76ee2e1c5ffba1fe61ede73fbea5630d61eee6fac4929c0c"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e85e2a16b12bdb763244c69ab79363d71db2b4b918a2def53f80b02e0574b13c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1868,6 +2194,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "sentry"
@@ -1946,6 +2278,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1978,6 +2321,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_tokenstream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a00ffd23fd882d096f09fcaae2a9de8329a328628e86027e049ee051dc1621f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1987,6 +2342,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cc7a1570e38322cfe4154732e5110f887ea57e22b76f4bfd32b5bdd3368666c"
+dependencies = [
+ "indexmap 2.1.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2049,6 +2417,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "slug"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3bc762e6a4b6c6fcaade73e77f9ebc6991b676f88bb2358bddb56560f073373"
+dependencies = [
+ "deunicode 0.4.5",
 ]
 
 [[package]]
@@ -2692,6 +3069,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "typeshare"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f44d1a2f454cb35fbe05b218c410792697e76bd868f48d3a418f2cd1a7d527d6"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "typeshare-annotation",
+]
+
+[[package]]
+name = "typeshare-annotation"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc670d0e358428857cc3b4bf504c691e572fccaec9542ff09212d3f13d74b7a9"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "typify"
+version = "0.0.14"
+source = "git+https://github.com/oxidecomputer/typify#c21dc2ec3644b80557c95be58d98ca00f210fd30"
+dependencies = [
+ "typify-impl",
+ "typify-macro",
+]
+
+[[package]]
+name = "typify-impl"
+version = "0.0.14"
+source = "git+https://github.com/oxidecomputer/typify#c21dc2ec3644b80557c95be58d98ca00f210fd30"
+dependencies = [
+ "heck",
+ "log",
+ "proc-macro2",
+ "quote",
+ "regress",
+ "schemars",
+ "serde_json",
+ "syn 2.0.38",
+ "thiserror",
+ "unicode-ident",
+]
+
+[[package]]
+name = "typify-macro"
+version = "0.0.14"
+source = "git+https://github.com/oxidecomputer/typify#c21dc2ec3644b80557c95be58d98ca00f210fd30"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_tokenstream",
+ "syn 2.0.38",
+ "typify-impl",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2719,10 +3159,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
 name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
 
 [[package]]
 name = "untrusted"
@@ -2877,6 +3329,19 @@ name = "wasm-bindgen-shared"
 version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
+
+[[package]]
+name = "wasm-streams"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"

--- a/ci-bench-runner/Cargo.toml
+++ b/ci-bench-runner/Cargo.toml
@@ -6,17 +6,28 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.75"
 axum = "0.6.20"
+bencher_client = { git = "https://github.com/bencherdev/bencher", rev = "22bbfb6f" }
 hex = "0.4.3"
 hmac = "0.12.1"
 hyper = { version = "0.14.27", default-features = false }
 jsonwebtoken = "9.1.0"
 octocrab = "0.32.0"
-sentry = { version = "0.31.7", features = ["tracing", "ureq", "rustls"], default-features = false }
+sentry = { version = "0.31.7", features = [
+    "tracing",
+    "ureq",
+    "rustls",
+], default-features = false }
 sentry-tracing = "0.31.7"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
 sha2 = "0.10.8"
-sqlx = { version = "0.7.2", features = ["runtime-tokio", "sqlite", "macros", "time", "migrate"], default-features = false }
+sqlx = { version = "0.7.2", features = [
+    "runtime-tokio",
+    "sqlite",
+    "macros",
+    "time",
+    "migrate",
+], default-features = false }
 tempfile = "3.8.0"
 time = { version = "0.3.29", features = ["formatting", "serde"] }
 tokio = { version = "1.32.0", features = ["rt", "rt-multi-thread", "macros"] }

--- a/ci-bench-runner/Cargo.toml
+++ b/ci-bench-runner/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.75"
 axum = "0.6.20"
-bencher_client = { git = "https://github.com/bencherdev/bencher", rev = "22bbfb6f" }
+bencher_client = { git = "https://github.com/bencherdev/bencher", rev = "d0532976" }
 hex = "0.4.3"
 hmac = "0.12.1"
 hyper = { version = "0.14.27", default-features = false }
@@ -38,5 +38,5 @@ uuid = { version = "1.4.1", features = ["v4", "serde"] }
 
 [dev-dependencies]
 ctor = "0.2.5"
-reqwest = "0.11.22"
+reqwest = { version = "0.11.22", default-features = false, features = ["rustls-tls"] }
 wiremock = "0.5.19"

--- a/ci-bench-runner/src/job/bench_main.rs
+++ b/ci-bench-runner/src/job/bench_main.rs
@@ -14,7 +14,7 @@ use crate::CommitIdentifier;
 
 use super::bencher::{new_bencher_report, send_report_to_bencher};
 
-const BRANCH_NAME: &str = "main";
+pub const MAIN_BRANCH: &str = "main";
 
 /// Handle a push to main
 ///
@@ -50,7 +50,7 @@ pub async fn bench_main(ctx: JobContext<'_>) -> anyhow::Result<()> {
         let result = bench_runner.checkout_and_run_benchmarks(
             &CommitIdentifier {
                 clone_url: payload.repository.clone_url,
-                branch_name: BRANCH_NAME.to_string(),
+                branch_name: MAIN_BRANCH.to_string(),
                 commit_sha,
             },
             &base_repo_path,
@@ -84,7 +84,7 @@ pub async fn bench_main(ctx: JobContext<'_>) -> anyhow::Result<()> {
         .context("failed to store benchmark results")?;
     let json_new_report = new_bencher_report(
         &ctx.config,
-        BRANCH_NAME,
+        MAIN_BRANCH,
         &payload.after,
         start_time,
         end_time,

--- a/ci-bench-runner/src/job/bencher.rs
+++ b/ci-bench-runner/src/job/bencher.rs
@@ -1,0 +1,97 @@
+use std::collections::HashMap;
+
+use bencher_client::{
+    json::{
+        project::metric_kind::INSTRUCTIONS_SLUG_STR, DateTime, JsonMetric, JsonMetricsMap,
+        JsonReport, JsonResultsMap, MetricKind,
+    },
+    types::{Adapter, JsonNewReport, JsonReportSettings},
+    BencherClient,
+};
+
+use crate::AppConfig;
+
+const DEFAULT_PROJECT_ID: &str = "rustls";
+const DEFAULT_TESTBED_ID: &str = "benchmarking-host";
+
+/// Create a new Bencher report
+pub fn new_bencher_report(
+    config: &AppConfig,
+    branch: &str,
+    hash: &str,
+    start_time: DateTime,
+    end_time: DateTime,
+    icounts: HashMap<String, f64>,
+) -> anyhow::Result<JsonNewReport> {
+    // Use `benchmarking-host` as the default Testbed ID
+    let testbed = config
+        .bencher_testbed_id
+        .clone()
+        .unwrap_or(DEFAULT_TESTBED_ID.parse().unwrap());
+
+    // The benchmark metric kind is "Instructions" which should have the slug `instructions`
+    let instructions: MetricKind = INSTRUCTIONS_SLUG_STR.parse().unwrap();
+
+    // Convert the instruction counts map into Bencher Metric Format (BMF)
+    // https://bencher.dev/docs/explanation/adapters#-json
+    let results: JsonResultsMap = icounts
+        .into_iter()
+        .filter_map(|(scenario_name, value)| {
+            let benchmark_name = scenario_name.parse().ok()?;
+            let mut metrics = JsonMetricsMap::new();
+            let metric = JsonMetric {
+                value: value.into(),
+                ..Default::default()
+            };
+            metrics.insert(instructions.clone(), metric);
+            Some((benchmark_name, metrics))
+        })
+        .collect();
+
+    Ok(JsonNewReport {
+        branch: branch.parse()?,
+        hash: Some(hash.parse()?),
+        testbed: testbed.into(),
+        start_time: start_time.into(),
+        end_time: end_time.into(),
+        results: vec![serde_json::to_string(&results)?],
+        settings: Some(JsonReportSettings {
+            adapter: Some(Adapter::Json),
+            average: None,
+            fold: None,
+        }),
+    })
+}
+
+/// Send the benchmark report to Bencher
+pub async fn send_report_to_bencher(
+    bencher_client: &BencherClient,
+    config: &AppConfig,
+    json_new_report: JsonNewReport,
+) -> anyhow::Result<()> {
+    // Use `rustls` as the default Project ID
+    let project_id = config
+        .bencher_project_id
+        .clone()
+        .unwrap_or(DEFAULT_PROJECT_ID.parse().unwrap());
+
+    let project_id = &project_id;
+    let new_report = &json_new_report;
+    // Send report over to Bencher
+    let report: JsonReport = bencher_client
+        .send_with(
+            |client| async move {
+                client
+                    .proj_report_post()
+                    .project(project_id.clone())
+                    .body(new_report.clone())
+                    .send()
+                    .await
+            },
+            false,
+        )
+        .await?;
+    tracing::trace!("{}", serde_json::to_string_pretty(&report)?);
+
+    Ok(())
+}

--- a/ci-bench-runner/src/job/bencher.rs
+++ b/ci-bench-runner/src/job/bencher.rs
@@ -11,7 +11,7 @@ use bencher_client::{
 
 use crate::AppConfig;
 
-const DEFAULT_PROJECT_ID: &str = "rustls";
+pub const DEFAULT_PROJECT_ID: &str = "rustls";
 const DEFAULT_TESTBED_ID: &str = "benchmarking-host";
 
 /// Create a new Bencher report

--- a/ci-bench-runner/src/job/mod.rs
+++ b/ci-bench-runner/src/job/mod.rs
@@ -11,6 +11,7 @@ pub use bench_pr::{handle_issue_comment, handle_pr_review, handle_pr_update};
 
 mod bench_main;
 mod bench_pr;
+mod bencher;
 
 /// Reads the (benchmark, result) pairs from previous CSV output
 fn read_results(path: &Path) -> anyhow::Result<HashMap<String, f64>> {

--- a/ci-bench-runner/src/lib.rs
+++ b/ci-bench-runner/src/lib.rs
@@ -20,6 +20,7 @@ use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
+use bencher_client::json::{Jwt, ResourceId};
 use serde::Deserialize;
 use sqlx::migrate::Migrator;
 use sqlx::SqliteConnection;
@@ -65,6 +66,12 @@ pub struct AppConfig {
     pub github_repo_name: String,
     /// Sentry DSN
     pub sentry_dsn: String,
+    /// Bencher API token
+    pub bencher_api_token: Jwt,
+    /// Bencher Project ID
+    pub bencher_project_id: Option<ResourceId>,
+    /// Bencher Testbed ID
+    pub bencher_testbed_id: Option<ResourceId>,
     /// Port where the application should listen (defaults to 0 if unset)
     pub port: Option<u16>,
 }

--- a/ci-bench-runner/src/test/mod.rs
+++ b/ci-bench-runner/src/test/mod.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::bail;
+use bencher_client::json::Jwt;
 use ctor::ctor;
 use hmac::digest::FixedOutput;
 use hmac::{Hmac, Mac};
@@ -694,6 +695,9 @@ fn test_config(tmp_path: &Path, github_url: String) -> Arc<AppConfig> {
         github_repo_owner: MockGitHub::REPO_OWNER.to_string(),
         github_repo_name: MockGitHub::REPO_NAME.to_string(),
         sentry_dsn: "".to_string(),
+        bencher_api_token: Jwt::test_token(),
+        bencher_project_id: None,
+        bencher_testbed_id: None,
         port: None,
     })
 }

--- a/readme.md
+++ b/readme.md
@@ -30,10 +30,19 @@ webhook's URL _and_ a secret to ensure event authenticity):
 - Pull request review.
 - Push.
 
-Make sure to set the GitHub webook URL for your application with the correct 
+Make sure to set the GitHub webook URL for your application with the correct
 `/webhooks/github` route, e.g.:
 
 - `https://my-domain.example.com/webhooks/github`
+
+#### Bencher
+
+The bench runner saves all of the results from `main` both locally and to [Bencher].
+In order to set up Bencher, you will need to set the following configuration options:
+
+- `bencher_api_token`: An API token for the Bencher Project.
+- `bencher_project_id`: (Optional) The Bencher Project UUID or slug. Defaults to `rustls`.
+- `bencher_testbed_id`: (Optional) The Bencher Testbed UUID or slug. Defaults to `benchmarking-host`.
 
 #### Server
 
@@ -44,7 +53,7 @@ Turbo Boost) and hyper threading. This needs to be done at the BIOS / UEFI level
 
 The following features are supported:
 
-- Run the benchmarks on every push to `main` and store the results.
+- Run the benchmarks on every push to `main` and store the results both locally and to [Bencher].
 - Calculate a per-benchmark significance threshold based on the result history for the `main` branch.
 - Run the benchmarks on pull requests, comparing the results against the pull request's base branch.
   For security, comparison bench runs are only triggered in the following scenarios:
@@ -77,3 +86,4 @@ directory.
 [Nix flake]: https://zero-to-nix.com/concepts/flakes
 [Install Nix]: https://nixos.org/
 [Direnv]: https://direnv.net/
+[Bencher]: https://bencher.dev/


### PR DESCRIPTION
These changes add tracking of the metrics for the `main` branch of `rustls` using Bencher.

In order to accomplish this, three configuration keys were added:
- `bencher_api_token`: An API token for https://bencher.dev
- `bencher_project_id`: (Optional) It sets the Bencher Project UUID or slug and defaults to `rustls`
- `bencher_testbed_id`: (Optional) It sets the Bencher Testbed UUID or slug and defaults to `benchmarking-host` (I'm very much up for suggestions on what the default should be here)

The `BencherClient` is constructed and stored in the `EventQueue` using the `bencher_api_token` key.
While the other two are used (if provided) at runtime to create and send the report to Bencher.

There were some minor formatting changes and whitespace cleanup done by my IDE automatically. If you would like for me to go back and revert these, please let me know.