### PR TITLE
flake: remove package definition

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,15 +30,7 @@
             inherit system;
             overlays = [ (import inputs.rust-overlay) ];
           };
-          packages.default = self'.packages.ci-bench-runner;
           devShells.default = self'.devShells.nightly;
-
-          packages.ci-bench-runner = pkgs.rustPlatform.buildRustPackage {
-            inherit (cargoToml.package) name version;
-            src = crateDir;
-            cargoLock = { lockFile = "${crateDir}/Cargo.lock"; };
-            doCheck = false; # Some tests require platform certs.
-          };
 
           # Nightly Rust dev env
           devShells.nightly = (mkDevShell (pkgs.rust-bin.selectLatestNightlyWith


### PR DESCRIPTION
A package derivation isn't very useful for this project. The deployment model assumes a Cargo based build on the remote server, orchestrated by Ansible. For local development we also prefer Cargo. Having the package derivation would be useful if we wanted to deploy with Nix, but we don't. It also makes taking Git dependencies in our Cargo.toml cumbersome, and may break builds of tools like bencher-client that aren't written with an isolated build environment in mind.