### PR TITLE
Use askama for templating markdown comments

### DIFF
--- a/ci-bench-runner/Cargo.lock
+++ b/ci-bench-runner/Cargo.lock
@@ -73,6 +73,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
+name = "askama"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79091df18a97caea757e28cd2d5fda49c6cd4bd01ddffd7ff01ace0c0ad2c28"
+dependencies = [
+ "askama_derive",
+ "askama_escape",
+ "humansize",
+ "num-traits",
+ "percent-encoding",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a0fc7dcf8bd4ead96b1d36b41df47c14beedf7b0301fc543d8f2384e66a2ec0"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "mime",
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.38",
+]
+
+[[package]]
+name = "askama_escape"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
+
+[[package]]
+name = "askama_parser"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c268a96e01a4c47c8c5c2472aaa570707e006a875ea63e819f75474ceedaf7b4"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,6 +244,15 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "basic-toml"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f2139706359229bfa8f19142ac1155b4b80beafb7a60471ac5dd109d4a19778"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bencher_client"
@@ -352,6 +405,7 @@ name = "ci-bench-runner"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "askama",
  "axum",
  "bencher_client",
  "ctor",
@@ -1043,6 +1097,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humansize"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1298,6 +1361,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -3024,6 +3097,15 @@ dependencies = [
  "serde_tokenstream",
  "syn 2.0.38",
  "typify-impl",
+]
+
+[[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]

--- a/ci-bench-runner/Cargo.toml
+++ b/ci-bench-runner/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.75"
+askama = "0.12.1"
 axum = "0.6.20"
 bencher_client = { git = "https://github.com/bencherdev/bencher", rev = "d0532976" }
 hex = "0.4.3"

--- a/ci-bench-runner/templates/comparison_error_comment.md
+++ b/ci-bench-runner/templates/comparison_error_comment.md
@@ -1,0 +1,21 @@
+{% import "macros.md" as macros %}
+
+# Error running benchmarks"
+
+Cause:
+
+```
+{{error}}
+```
+
+{% call macros::checkout_details(branches) %}
+
+## Logs
+
+### Candidate
+
+{{ candidate_logs }}
+
+### Baseline
+
+{{ baseline_logs }}

--- a/ci-bench-runner/templates/comparison_success_comment.md
+++ b/ci-bench-runner/templates/comparison_success_comment.md
@@ -1,0 +1,52 @@
+{% import "macros.md" as macros %}
+
+# Benchmark results
+
+{% if scenarios_missing_in_baseline.len() > 0 %}
+
+### ⚠️ Warning: missing benchmarks
+
+The following benchmark scenarios are present in the candidate but not in the baseline:
+
+{% for scenario in scenarios_missing_in_baseline %}
+* {{scenario}}
+{% endfor %}
+
+{% endif %}
+
+## Significant instruction count differences
+
+{% if significant_icount_diffs.is_empty() %}
+
+_There are no significant instruction count differences_
+
+{% else %}
+
+{% call macros::table(significant_icount_diffs, cachegrind_diff_url, true) %}
+
+{% endif %}
+
+## Other instruction count differences
+
+{% if significant_icount_diffs.is_empty() %}
+
+_There are no other instruction count differences_
+
+{% else %}
+
+<details>
+<summary>Click to expand</summary>
+
+{% call macros::table(negligible_icount_diffs, cachegrind_diff_url, false) %}
+
+</details>
+
+{% endif %}
+
+## Additional information
+
+{% if let Some(project_id) = bencher_project_id %}
+[Historical results](https://bencher.dev/perf/{{project_id}})
+{% endif %}
+
+{% call macros::checkout_details(branches) %}

--- a/ci-bench-runner/templates/macros.md
+++ b/ci-bench-runner/templates/macros.md
@@ -1,0 +1,27 @@
+{%- macro table(diffs, cachegrind_diff_url, use_emoji) -%}
+
+| Scenario | Baseline | Candidate | Diff | Threshold |
+| --- | ---: | ---: | ---: | ---: |
+{% for diff in diffs %}
+{%- let emoji -%}
+{%- if use_emoji && diff.diff() > 0.0 -%}
+{%- let emoji = "⚠️ " -%}
+{%- else if use_emoji && diff.diff() < 0.0 -%}
+{%- let emoji = "✅ " -%}
+{%- else -%}
+{%- let emoji = "" -%}
+{%- endif -%}
+| {{ diff.scenario_name }} | {{ diff.baseline_result }} | {{ diff.candidate_result }} | {{emoji}}[{{diff.diff()}}]({{cachegrind_diff_url}}/{{diff.scenario_name}}) ({{ "{:.2}%"|format(diff.diff_ratio() * 100.0) }}) | {{ "{:.2}%"|format(diff.significance_threshold * 100.0) }} |
+{% endfor %}
+{%- endmacro -%}
+
+{%- macro checkout_details(branches) -%}
+
+Checkout details:
+
+- Base repo: {{branches.baseline.clone_url}}
+- Base branch: {{branches.baseline.branch_name}} ({{branches.baseline.commit_sha}})
+- Candidate repo: {{branches.candidate.clone_url}}
+- Candidate branch: {{branches.candidate.branch_name}} ({{branches.candidate.commit_sha}})
+
+{%- endmacro -%}


### PR DESCRIPTION
Comments will become a bit more complex once we have walltime benchmarks, and we seem to be reaching the point where building them by manipulating strings is too much of a hassle.