### PR TITLE
Support benchmarks using wall-time mode

### DIFF
--- a/ci-bench-runner/migrations/0_create.sql
+++ b/ci-bench-runner/migrations/0_create.sql
@@ -8,6 +8,7 @@ CREATE INDEX idx_bench_runs_created_utc ON bench_runs(created_utc);
 CREATE TABLE bench_results(
    bench_run_id BLOB NOT NULL,
    scenario_name TEXT NOT NULL,
+   scenario_kind INTEGER NOT NULL,
    result REAL NOT NULL,
    FOREIGN KEY (bench_run_id) REFERENCES bench_runs(id)
 ) STRICT;
@@ -17,7 +18,8 @@ CREATE TABLE comparison_runs(
     created_utc TEXT NOT NULL,
     baseline_commit TEXT NOT NULL,
     candidate_commit TEXT NOT NULL,
-    scenarios_missing_in_baseline TEXT
+    icount_scenarios_missing_in_baseline TEXT,
+    walltime_scenarios_missing_in_baseline TEXT
 ) STRICT;
 
 CREATE INDEX idx_comparison_run_commits ON comparison_runs(baseline_commit, candidate_commit);
@@ -32,6 +34,8 @@ CREATE TABLE scenario_diffs(
     cachegrind_diff TEXT NOT NULL,
     FOREIGN KEY (comparison_run_id) REFERENCES comparison_runs(id)
 ) STRICT;
+
+CREATE INDEX idx_scenario_diffs_by_kind ON scenario_diffs(comparison_run_id, scenario_kind);
 
 CREATE TABLE event_queue(
     id BLOB PRIMARY KEY,

--- a/ci-bench-runner/src/job/mod.rs
+++ b/ci-bench-runner/src/job/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, bail, Context};
 use tracing::trace;
@@ -13,10 +13,10 @@ mod bench_main;
 mod bench_pr;
 
 /// Reads the (benchmark, result) pairs from previous CSV output
-fn read_results(path: &Path) -> anyhow::Result<HashMap<String, f64>> {
+fn read_icount_results(path: &Path) -> anyhow::Result<HashMap<String, f64>> {
     trace!(
         path = path.display().to_string(),
-        "reading comparison results from CSV file"
+        "reading icount results from CSV file"
     );
     let file = File::open(path).context(format!(
         "CSV file for comparison not found: {}",
@@ -46,4 +46,44 @@ fn read_results(path: &Path) -> anyhow::Result<HashMap<String, f64>> {
     }
 
     Ok(measurements)
+}
+
+/// Reads the (benchmark, result) pairs from previous CSV output
+pub fn read_walltime_results(path: &Path) -> anyhow::Result<HashMap<String, f64>> {
+    trace!(
+        path = path.display().to_string(),
+        "reading walltime results from CSV file"
+    );
+
+    let mut results = HashMap::new();
+    let results_file = File::open(path)?;
+    for line in BufReader::new(results_file).lines() {
+        let line = line.context("failed to read line from CSV file")?;
+        let line = line.trim();
+        let mut parts = line.split(',');
+
+        let scenario = parts.next().ok_or(anyhow!("empty line"))?.to_string();
+        let walltimes: Result<Vec<_>, _> = parts.map(|s| s.parse::<u128>()).collect();
+        let mut walltimes = walltimes.context("invalid f64 in row")?;
+
+        if walltimes.is_empty() {
+            bail!("no measurements for walltime results row");
+        }
+
+        // Take the median of the results as the official wall-time
+        walltimes.sort_unstable();
+        let walltime = walltimes[walltimes.len() / 2] as f64;
+
+        results.insert(scenario, walltime);
+    }
+
+    Ok(results)
+}
+
+fn icounts_path(base: &Path) -> PathBuf {
+    base.join("results/icounts.csv")
+}
+
+pub fn walltimes_path(base: &Path) -> PathBuf {
+    base.join("results/walltimes.csv")
 }

--- a/ci-bench-runner/templates/comparison_success_comment.md
+++ b/ci-bench-runner/templates/comparison_success_comment.md
@@ -2,33 +2,32 @@
 
 # Benchmark results
 
-{% if scenarios_missing_in_baseline.len() > 0 %}
+## Instruction counts
 
-### ⚠️ Warning: missing benchmarks
+{% call macros::missing_scenarios(icount.scenarios_missing_in_baseline) %}
 
-The following benchmark scenarios are present in the candidate but not in the baseline:
+#### Significant differences
 
-{% for scenario in scenarios_missing_in_baseline %}
-* {{scenario}}
-{% endfor %}
-
-{% endif %}
-
-## Significant instruction count differences
-
-{% if significant_icount_diffs.is_empty() %}
+{% if icount.significant_diffs.is_empty() %}
 
 _There are no significant instruction count differences_
 
 {% else %}
 
-{% call macros::table(significant_icount_diffs, cachegrind_diff_url, true) %}
+⚠️ There are significant instruction count differences
+
+<details>
+<summary>Click to expand</summary>
+
+{% call macros::icount_table(icount.significant_diffs, cachegrind_diff_url, true) %}
+
+</details>
 
 {% endif %}
 
-## Other instruction count differences
+#### Other differences
 
-{% if significant_icount_diffs.is_empty() %}
+{% if icount.significant_diffs.is_empty() %}
 
 _There are no other instruction count differences_
 
@@ -37,7 +36,47 @@ _There are no other instruction count differences_
 <details>
 <summary>Click to expand</summary>
 
-{% call macros::table(negligible_icount_diffs, cachegrind_diff_url, false) %}
+{% call macros::icount_table(icount.negligible_diffs, cachegrind_diff_url, false) %}
+
+</details>
+
+{% endif %}
+
+## Wall-time
+
+{% call macros::missing_scenarios(walltime.scenarios_missing_in_baseline) %}
+
+#### Significant differences
+
+{% if walltime.significant_diffs.is_empty() %}
+
+_There are no significant wall-time differences_
+
+{% else %}
+
+⚠️ There are significant wall-time differences
+
+<details>
+<summary>Click to expand</summary>
+
+{% call macros::walltime_table(walltime.significant_diffs, true) %}
+
+</details>
+
+{% endif %}
+
+#### Other differences
+
+{% if walltime.negligible_diffs.is_empty() %}
+
+_There are no other wall-time count differences_
+
+{% else %}
+
+<details>
+<summary>Click to expand</summary>
+
+{% call macros::walltime_table(walltime.negligible_diffs, false) %}
 
 </details>
 

--- a/ci-bench-runner/templates/macros.md
+++ b/ci-bench-runner/templates/macros.md
@@ -1,4 +1,21 @@
-{%- macro table(diffs, cachegrind_diff_url, use_emoji) -%}
+{%- macro missing_scenarios(scenarios_missing_in_baseline) -%}
+
+{% if scenarios_missing_in_baseline.len() > 0 %}
+
+#### ⚠️ Missing benchmarks
+
+The following benchmark scenarios are present in the candidate but not in the baseline:
+
+{% for scenario in scenarios_missing_in_baseline %}
+* {{scenario}}
+{% endfor %}
+
+{% endif %}
+
+{%- endmacro -%}
+
+
+{%- macro icount_table(diffs, cachegrind_diff_url, use_emoji) -%}
 
 | Scenario | Baseline | Candidate | Diff | Threshold |
 | --- | ---: | ---: | ---: | ---: |
@@ -13,7 +30,29 @@
 {%- endif -%}
 | {{ diff.scenario_name }} | {{ diff.baseline_result }} | {{ diff.candidate_result }} | {{emoji}}[{{diff.diff()}}]({{cachegrind_diff_url}}/{{diff.scenario_name}}) ({{ "{:.2}%"|format(diff.diff_ratio() * 100.0) }}) | {{ "{:.2}%"|format(diff.significance_threshold * 100.0) }} |
 {% endfor %}
+
 {%- endmacro -%}
+
+
+{%- macro walltime_table(diffs, use_emoji) -%}
+
+| Scenario | Baseline | Candidate | Diff | Threshold |
+| --- | ---: | ---: | ---: | ---: |
+{% for diff in diffs %}
+{%- let emoji -%}
+{%- if use_emoji && diff.diff() > 0.0 -%}
+{%- let emoji = "⚠️ " -%}
+{%- else if use_emoji && diff.diff() < 0.0 -%}
+{%- let emoji = "✅ " -%}
+{%- else -%}
+{%- let emoji = "" -%}
+{%- endif -%}
+{%- let unit = common_time_unit(diff.baseline_result, diff.candidate_result) -%}
+| {{ diff.scenario_name }} | {{ diff.baseline_result|format_timing(unit) }} | {{ diff.candidate_result|format_timing(unit) }} | {{emoji}}{{diff.diff()|format_timing(unit)}} ({{ "{:.2}%"|format(diff.diff_ratio() * 100.0) }}) | {{ "{:.2}%"|format(diff.significance_threshold * 100.0) }} |
+{% endfor %}
+
+{%- endmacro -%}
+
 
 {%- macro checkout_details(branches) -%}
 


### PR DESCRIPTION
See [this comment](https://github.com/aochagavia/rustls/pull/11#issuecomment-1822483102) for example output (from a run on the bare-metal server). The noise is incredibly low! If such low level of noise is consistent over time, we might not even need the icount benchmarks 🤔. By contrast, the [previous comment](https://github.com/aochagavia/rustls/pull/11#issuecomment-1822431509) shows results from a run on my laptop and are pretty noisy.

Relevant changes (pretty intertwined, so all in a single commit):

- Track `scenario_kind` in `bench_results` table
- Gather walltime results next to icount results
- Report walltime results in the GH comment, after icount results
- Push walltime results to bencher
- Cache walltime results to database

Btw, I discovered a few more ansible issues, which I'll tackle in a separate PR. There is also an issue in the sorting of the diffs, unrelated to this PR, which I'll fix separately too.