### PR TITLE
db: make cachegrind diff nullable

### DIFF
--- a/ci-bench-runner/migrations/0_create.sql
+++ b/ci-bench-runner/migrations/0_create.sql
@@ -31,7 +31,7 @@ CREATE TABLE scenario_diffs(
     baseline_result REAL NOT NULL,
     candidate_result REAL NOT NULL,
     significance_threshold REAL NOT NULL,
-    cachegrind_diff TEXT NOT NULL,
+    cachegrind_diff TEXT,
     FOREIGN KEY (comparison_run_id) REFERENCES comparison_runs(id)
 ) STRICT;
 

--- a/ci-bench-runner/src/job/bench_pr.rs
+++ b/ci-bench-runner/src/job/bench_pr.rs
@@ -551,9 +551,9 @@ fn compare_results(
         };
 
         let cachegrind_diff = if scenario_kind == ScenarioKind::Icount {
-            cachegrind_diff(job_output_path, scenario)?
+            Some(cachegrind_diff(job_output_path, scenario)?)
         } else {
-            "No cachegrind diff available (this is a walltime benchmark)".to_string()
+            None
         };
 
         diffs.push(ScenarioDiff {
@@ -779,7 +779,7 @@ mod test {
                 baseline_result: baseline,
                 candidate_result: candidate,
                 significance_threshold: f64::MAX, // Everything is negligible
-                cachegrind_diff: String::new(),
+                cachegrind_diff: Some(String::new()),
             }
         }
 

--- a/ci-bench-runner/src/test/mod.rs
+++ b/ci-bench-runner/src/test/mod.rs
@@ -403,7 +403,7 @@ async fn test_pr_synchronize_cached() {
                         baseline_result: 1000.0,
                         candidate_result: 1001.0,
                         significance_threshold: 0.35,
-                        cachegrind_diff: "dummy cachegrind diff".to_string(),
+                        cachegrind_diff: Some("dummy cachegrind diff".to_string()),
                     }],
                 },
                 walltime: ComparisonSubResult {
@@ -584,7 +584,7 @@ async fn test_get_cachegrind_diff() {
                         baseline_result: 1000.0,
                         candidate_result: 1001.0,
                         significance_threshold: 0.35,
-                        cachegrind_diff: "dummy cachegrind diff".to_string(),
+                        cachegrind_diff: Some("dummy cachegrind diff".to_string()),
                     }],
                 },
                 walltime: ComparisonSubResult {


### PR DESCRIPTION
This more properly reflects the fact that scenario_diffs for walltime benchmarks don't have a cachegrind diff